### PR TITLE
Update ApiAuthorization class to support non-standard http port

### DIFF
--- a/ApiUtilLib/ApiAuthorization.cs
+++ b/ApiUtilLib/ApiAuthorization.cs
@@ -317,7 +317,17 @@ namespace ApiUtilLib
                 }
 
                 // make sure that the port no and querystring are remove from url
-                var url = string.Format("{0}://{1}{2}", siteUri.Scheme, siteUri.Host, siteUri.AbsolutePath);
+                string url;
+
+                if(siteUri.Port==-1 || siteUri.Port==80 || siteUri.Port == 443)
+                {
+                    url = string.Format("{0}://{1}{2}", siteUri.Scheme, siteUri.Host, siteUri.AbsolutePath);
+                }
+                else
+                {
+                    url = string.Format("{0}://{1}:{2}{3}", siteUri.Scheme, siteUri.Host, siteUri.Port, siteUri.AbsolutePath);
+                }
+
                 Logger.LogInformation("url:: {0}", url);
 
                 // helper calss that handle parameters and form fields


### PR DESCRIPTION
# Description

To Update ApiAuthorization class to support non-standard http port

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Validate using test-suites

